### PR TITLE
Add support for extended fields and add missing ARIN provider

### DIFF
--- a/providers.go
+++ b/providers.go
@@ -46,19 +46,23 @@ var (
 	AllProviders = []*CachedProvider{
 		NewCachedProvider(
 			"afrinic",
-			"http://ftp.apnic.net/stats/afrinic/delegated-afrinic-latest",
+			"http://ftp.apnic.net/stats/afrinic/delegated-afrinic-extended-latest",
 		),
 		NewCachedProvider(
 			"apnic",
-			"http://ftp.apnic.net/stats/apnic/delegated-apnic-latest",
+			"http://ftp.apnic.net/stats/apnic/delegated-apnic-extended-latest",
 		),
 		NewCachedProvider(
 			"lacnic",
-			"http://ftp.apnic.net/stats/lacnic/delegated-lacnic-latest",
+			"http://ftp.apnic.net/stats/lacnic/delegated-lacnic-extended-latest",
 		),
 		NewCachedProvider(
 			"ripencc",
-			"http://ftp.apnic.net/stats/ripe-ncc/delegated-ripencc-latest",
+			"http://ftp.apnic.net/stats/ripe-ncc/delegated-ripencc-extended-latest",
+		),
+		NewCachedProvider(
+			"arin",
+			"http://ftp.arin.net/pub/stats/arin/delegated-arin-extended-latest",
 		),
 		//NewCachedProvider(
 		//	"iana",

--- a/reader.go
+++ b/reader.go
@@ -32,9 +32,9 @@ type (
 	}
 
 	Record struct {
-		Registry, Cc, Type string
-		Value              int
-		Date, Status       string
+		Registry, Cc, Type     string
+		Value                  int
+		Date, Status, OpaqueId string
 	}
 
 	IpRecord struct {
@@ -176,17 +176,23 @@ func (p *parser) parseSummary() *Summary {
 }
 
 func (p *parser) parseIp() *IpRecord {
+	if len(p.fields) == 7 {
+		p.fields = append(p.fields, "")
+	}
 	return &IpRecord{
 		&Record{p.fields[0], p.fields[1], p.fields[2],
-			p.toInt(p.fields[4]), p.fields[5], p.fields[6]},
+			p.toInt(p.fields[4]), p.fields[5], p.fields[6], p.fields[7]},
 		net.ParseIP(p.fields[3]),
 	}
 }
 
 func (p *parser) parseAsn() *AsnRecord {
+	if len(p.fields) == 7 {
+		p.fields = append(p.fields, "")
+	}
 	return &AsnRecord{
 		&Record{p.fields[0], p.fields[1], p.fields[2],
-			p.toInt(p.fields[4]), p.fields[5], p.fields[6]},
+			p.toInt(p.fields[4]), p.fields[5], p.fields[6], p.fields[7]},
 		p.toInt(p.fields[3]),
 	}
 }


### PR DESCRIPTION
These changes add the OpaqueId field available in extended RIR files, which allows the addition of the missing ARIN provider
